### PR TITLE
document misc endpoints and url parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ When working with Shopify URLs, you can use various query parameters and JSON en
 - `?page=<page-number>`: Used for pagination on collection pages, allowing users to navigate between multiple pages of products.
 - `?type=<collection-type>`: Collection type query to filter products by specific types.
 - `?filter=<filter-query>`: Applies filtering options to collections, such as price or tag filters.
+- `?limit=<number>`: Applies custom pagination limit. Useful for querying products on a store in bulk, or retrieving a small subset of products for a specific collection.
 
 
 ### Shopify (JSON) Endpoints:
@@ -29,6 +30,10 @@ When working with Shopify URLs, you can use various query parameters and JSON en
 - `/search/suggest.json?q=<query>&resources[type]=product`: Provides product search suggestions in JSON format based on the query.
 - `/pages/<page-handle>.json`: Retrieves details for a specific page in JSON format.
 - `/challenge`: Redirects to a challenge page, which Shopify uses for security purposes, like verifying the user is human when suspicious behavior is detected.
+- `/variants/<variant-id>`: Redirects to product page with variant preselected.
+- `/meta.json`: Retrieves store metadata.
+- `/browsing_context_suggestions.json`: Retrieves geolocation data.
+- `/products.json`: Retrieves all products on the store (paginated).
 
 <br>
 


### PR DESCRIPTION
Documents `/variant/<variant-id>`, `meta.json`, `browsing_context_suggestions` and `products.json` endpoints.

Also adds documentation for `limit` query parameter.

---

First of all - great idea for a repo! There's a lot of hidden features across Liquid storefronts and knowledge bases like this are really helpful for the community. I love discovering new endpoints!

The `/variants/<variant-id>` endpoint isn't a JSON endpoint, but since challenge endpoint is already documented in that list I figured I'd add it here and let you decide how you want to manage it.

`browing_context_suggestions.json` supports a few query params (you can find them here https://shopify.dev/docs/storefronts/themes/markets/localization-discovery#step-1-query-for-browsing-context-suggestions), but I don't know if and how you want to document those.

Another thing worth noting - a few endpoints work with both `.json` and `.js` extensions, but the data they return isn't necessarily exactly the same. For example `/products/<handle>.json` nests all data inside a `product` object, and tags are returned in one string, whereas `/products/<handle>.js` doesn't nest the data and tags are returned inside an array.